### PR TITLE
cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"strconv"
 	"sync"
 )

--- a/normalize_url.go
+++ b/normalize_url.go
@@ -21,8 +21,6 @@ func normalizeURL(inputURL string) (string, error) {
 	return resultURL, nil
 }
 
-// I'm pretty sure this can be done in a better way BUT Descendants() is
-// recursive already, so techniacally not n^2
 func getURLsFromHTML(htmlBody, rawBaseURL string) ([]string, error) {
 	var str []string
 


### PR DESCRIPTION
No need for organizing struct, all data type sizes for struct variables are 8 bytes